### PR TITLE
Fix OptimizelyClientListener access level

### DIFF
--- a/src/main/java/com/mparticle/kits/OptimizelyKit.java
+++ b/src/main/java/com/mparticle/kits/OptimizelyKit.java
@@ -340,7 +340,7 @@ public class OptimizelyKit extends KitIntegration implements KitIntegration.Even
         }
     }
 
-    interface OptimizelyClientListener {
+    public interface OptimizelyClientListener {
         void onOptimizelyClientAvailable(OptimizelyClient optimizelyClient);
     }
 }


### PR DESCRIPTION
This class should be public, since it is part of our OptimizelyKit API