### PR TITLE
Bump optimizely sdk dep to 3.5.0.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ android {
 }
 
 dependencies {
-    implementation 'com.optimizely.ab:android-sdk:3.2.1'
+    implementation 'com.optimizely.ab:android-sdk:3.5.0'
 
     testImplementation 'junit:junit:4.12'
     testImplementation files('libs/java-json.jar')


### PR DESCRIPTION
This version fixes a bad strictmode violation with many disk reads on the main thread. https://github.com/optimizely/android-sdk/issues/320.

See full diff here: https://github.com/optimizely/android-sdk/compare/3.2.1...3.5.0